### PR TITLE
Simplify getJibContainerBuilder

### DIFF
--- a/mill-docker/src/com/ofenbeck/mill/docker/DockerJibModule.scala
+++ b/mill-docker/src/com/ofenbeck/mill/docker/DockerJibModule.scala
@@ -136,7 +136,7 @@ trait DockerJibModule extends Module { outer: JavaModule =>
       implicit def jsonCodec: upickle.default.ReadWriter[BuildResult] = upickle.default.macroRW
     }
 
-    /** The JavaContainerBuilder before it is used to build the container. This will setup the JavaContainer in default
+    /** The JavaContainerBuilder before it is used to build the container. This will set up the JavaContainer in default
       * Jib Java Layer format
       * @return
       *   The return value is used for further processing of the JavaContainerBuilder - so full replacement is possible.
@@ -157,7 +157,7 @@ trait DockerJibModule extends Module { outer: JavaModule =>
     /** This method mainly exists to allow for customization of the JibContainerBuilder. It first creates a
       * JavaContainerBuilder via the Java Builder and then converts it to a JibContainerBuilder.
       *
-      * By default it will just readd the same layers - but by overriding as seen in the example this can be customized.
+      * By default, it will just readd the same layers - but by overriding as seen in the example this can be customized.
       *
       * @return
       *   The return value is used for further processing of the JibContainerBuilder - so full replacement is possible.

--- a/mill-docker/src/com/ofenbeck/mill/docker/MDBuild.scala
+++ b/mill-docker/src/com/ofenbeck/mill/docker/MDBuild.scala
@@ -1,28 +1,9 @@
 package com.ofenbeck.mill.docker
 
-import com.google.cloud.tools.jib.api.Containerizer
-import com.google.cloud.tools.jib.api.ImageReference
-import com.google.cloud.tools.jib.api.JavaContainerBuilder
-import com.google.cloud.tools.jib.api.Jib
-import com.google.cloud.tools.jib.api.JibContainerBuilder
-import com.google.cloud.tools.jib.api.LogEvent
-import coursier.core.shaded.sourcecode.File
-import mill.scalalib.JavaModule
-import os.group.set
+import com.google.cloud.tools.jib.api._
+import com.google.cloud.tools.jib.api.buildplan.{FileEntriesLayer, ImageFormat, LayerObject, Port}
 
-import java.time.Instant
 import scala.jdk.CollectionConverters._
-import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer
-import com.google.cloud.tools.jib.api.RegistryImage
-import com.google.cloud.tools.jib.api.DockerDaemonImage
-import com.google.cloud.tools.jib.api.TarImage
-import com.google.cloud.tools.jib.api.buildplan.ImageFormat
-import com.google.cloud.tools.jib.api.buildplan.Port
-import com.google.cloud.tools.jib.api.MainClassFinder
-import com.google.cloud.tools.jib.api.buildplan.LayerObject
-import com.google.cloud.tools.jib.api.buildplan.FileEntry
-import mill.define.Command
-import mill._, define.Task
 
 object MDBuild {
 
@@ -31,7 +12,6 @@ object MDBuild {
       buildSettings: BuildSettings,
       logger: mill.api.Logger,
   ): JavaContainerBuilder = {
-    // JibContainerBuilder = {
 
     val javaBuilder = buildSettings.sourceImage match {
       case JibImage.RegistryImage(qualifiedName, credentialsEnvironment) =>
@@ -42,7 +22,7 @@ object MDBuild {
           case None =>
         }
         JavaContainerBuilder.from(image)
-      case JibImage.DockerDaemonImage(qualifiedName, useFallBack, fallBackEnvCredentials) =>
+      case JibImage.DockerDaemonImage(qualifiedName, _, _) =>
         JavaContainerBuilder.from(DockerDaemonImage.named(ImageReference.parse(qualifiedName)))
       case JibImage.SourceTarFile(path) =>
         JavaContainerBuilder.from(TarImage.at(path.path.wrapped))
@@ -147,7 +127,6 @@ object MDBuild {
   def setContainerParams(
       dockerSettings: DockerSettings,
       buildSettings: BuildSettings,
-      logger: mill.api.Logger,
       containerBuilder: JibContainerBuilder,
   ): JibContainerBuilder = {
 
@@ -166,13 +145,12 @@ object MDBuild {
       case JibImageFormat.Docker => ImageFormat.Docker
       case JibImageFormat.OCI    => ImageFormat.OCI
     })
-    import com.google.cloud.tools.jib.api.buildplan.Port.tcp
-    import com.google.cloud.tools.jib.api.buildplan.Port.udp
+    import com.google.cloud.tools.jib.api.buildplan.Port.{tcp, udp}
     val ports: Set[Port] =
       dockerSettings.exposedPorts.map(p => tcp(p)).toSet ++ dockerSettings.exposedUdpPorts.map(p => udp(p)).toSet
     containerBuilder.setExposedPorts(ports.asJava)
     containerBuilder.setCreationTime(MDShared.useCurrentTimestamp(buildSettings.useCurrentTimestamp))
-    dockerSettings.entrypoint.foreach(entrypoint => containerBuilder.setEntrypoint(dockerSettings.entrypoint.asJava))
+    containerBuilder.setEntrypoint(dockerSettings.entrypoint.asJava)
     containerBuilder
   }
 


### PR DESCRIPTION
I have one more idea. I think we can radically simplify the default `getJibContainerBuilder` -- the user can always adjust it by overriding (and potentially calling `super.getJibContainerBuilder`).