### PR TITLE
feat: add moduleDeps classes to the classpath

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -54,7 +54,7 @@ object `mill-docker` extends ScalaModule with PublishModule {
   // Set the `platformSuffix` so the name indicates what Mill version it is compiled for
   def platformSuffix = "_mill" + mill.main.BuildInfo.millBinPlatform
 
-  override def publishVersion: T[String] = "0.0.2"
+  override def publishVersion: T[String] = "0.0.3"
 
   override def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"com.lihaoyi:mill-dist:$millVersion",

--- a/mill-docker/src/com/ofenbeck/mill/docker/MDBuild.scala
+++ b/mill-docker/src/com/ofenbeck/mill/docker/MDBuild.scala
@@ -51,8 +51,12 @@ object MDBuild {
     val (upstreamClassSnapShot, upstreamClass) =
       buildSettings.upstreamAssemblyClasspath.partition(MDShared.isSnapshotDependency(_))
 
-    javaBuilder.addDependencies(upstreamClass.filter(x => os.exists(x.path)).map(x => x.path.wrapped).toList.asJava)
+    val (moduleDeps, libraryDeps) =
+      upstreamClass.partition(MDShared.isModuleDep(_))
+
+    javaBuilder.addDependencies(libraryDeps.filter(x => os.exists(x.path)).map(x => x.path.wrapped).toList.asJava)
     javaBuilder.addSnapshotDependencies(upstreamClassSnapShot.map(_.path.wrapped).toList.asJava)
+    javaBuilder.addToClasspath(moduleDeps.filter(x => os.isDir(path)).map(_.path.wrapped).toList.asJava)
 
     buildSettings.unmanagedDependencies
       .filter(p => os.exists(p.path))

--- a/mill-docker/src/com/ofenbeck/mill/docker/MDSettings.scala
+++ b/mill-docker/src/com/ofenbeck/mill/docker/MDSettings.scala
@@ -16,6 +16,7 @@ object MDShared {
     if (useCurrentTimestamp) Instant.now() else Instant.EPOCH
 
   def isSnapshotDependency(millpath: mill.PathRef) = millpath.path.last.endsWith("-SNAPSHOT.jar")
+  def isModuleDep(millpath: mill.PathRef) = millpath.path.last.endsWith("classes")
 
   def retrieveEnvCredentials(usernameEnv: String, passwordEnv: String): CredentialRetriever =
     new CredentialRetriever {


### PR DESCRIPTION
# Motivation

In my code, I am building images with this plugin, but I've had trouble getting the resulting images to run due to `ClassDefNotFound` errors on startup. Eventually it clicked that these were classes from my `moduleDeps`, and sure enough `dive` showed `app/classes.jar/` was empty in the resulting images. I think this is just down to the `moduleDeps` ending up as class files rather than JARs, so `addDependencies` just ignores them.

# Result
I've added a fairly fragile heuristic to grab the `compile.dest/classes` paths from the `upstreamAssemblyClasspath` passed into `MDBuild` and use them with `addToClasspath`, which recursively copies the passed directories into `/app/classpath/` (preserving the directory structure) and adds `/app/classpath/` to the default entrypoint.

It would probably be better to use `transitiveLocalClasspath` since it _only_ contains `moduleDeps` outputs, but I figured I'd get this out sooner than later so I don't have to maintain my little workaround.

# Workaround

Until this is released, the same effect can be achieved with a line like

```
builder.addToClasspath(transitiveLocalClasspath().filter(_.path.last.endsWith("classes")).map(_.path.wrapped).toList.asJava
```

in an overridden `getJavaBuilder`.